### PR TITLE
add support -o Args to specifies the output file name

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -39,6 +39,7 @@ gopm build <go build commands>`,
 		cli.BoolFlag{"update, u", "update pakcage(s) and dependencies if any", ""},
 		cli.BoolFlag{"remote, r", "build with pakcages in gopm local repository only", ""},
 		cli.BoolFlag{"verbose, v", "show process details", ""},
+		cli.StringFlag{"o", "output", "specifies the output file name", ""},
 	},
 }
 
@@ -56,6 +57,10 @@ func buildBinary(ctx *cli.Context, args ...string) error {
 
 	cmdArgs := []string{"go", "build"}
 	cmdArgs = append(cmdArgs, args...)
+	if len(ctx.String("o")) > 0 {
+		cmdArgs = append(cmdArgs, "-o")
+		cmdArgs = append(cmdArgs, ctx.String("o"))
+	}
 	if len(ctx.String("tags")) > 0 {
 		cmdArgs = append(cmdArgs, "-tags")
 		cmdArgs = append(cmdArgs, ctx.String("tags"))


### PR DESCRIPTION
增加对原生 go build -o 这个参数的支持。

发现这个问题是在 gopm 配合 bee 工具使用的时候，bee会传入 -o 参数来定义编译出来的文件名，如果配合gopm则会失败。只要添加这个-o 参数支持就可以了。
