### PR TITLE
Change clean cmd. remove localnodes.list if option is 'all'.

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -44,6 +44,7 @@ func runClean(ctx *cli.Context) {
 
 	os.RemoveAll(path.Join(setting.HomeDir, ".gopm/temp"))
 	if ctx.Bool("all") {
+		os.Remove(path.Join(setting.HomeDir, ".gopm/data/localnodes.list"))
 		os.RemoveAll(setting.InstallRepoPath)
 	}
 }


### PR DESCRIPTION

this cmd has issue. maybe

```
> gopm clean -a
```

following dir is deleted after exec `gopm clean -a`.
* .gopm/temp
* .gopm/repos

but following file is not deleted.
* .gopm/data/localnodes.list

in this case, 
`go get` will be failed, because re- acquisition of dependency is not performed. 

please look this.
```
> gopm get -g -v -u
・・・
[GOPM] 15-11-12 11:24:44 [ INFO] Command executed successfully!

> gopm clean -a

> gopm get -g -v -u
[GOPM] 15-11-12 11:52:15 [ INFO] App Version: 0.8.6.1025 Beta
[GOPM] 15-11-12 11:52:15 [ INFO] Local repository path: /user/home/.gopm/repos
[GOPM] 15-11-12 11:52:15 [ INFO] Indicated GOPATH: /user/home/git/myproject
・・・
[GOPM] 15-11-12 11:52:40 [ INFO] Downloading package: github.com/hoge/test@branch:<UTD>
[GOPM] 15-11-12 11:52:41 [ INFO] Package(github.com/hoge/test) hasn't been changed
[GOPM] 15-11-12 11:52:41 [DEBUG] Linking github.com/hoge/test...
[GOPM] 15-11-12 11:52:41 [ INFO] Got github.com/hoge/test@branch:<UTD>
[GOPM] 15-11-12 11:52:41 [ERROR] %!(EXTRA string=Fail to copy to GOPATH:)
[GOPM] 15-11-12 11:52:41 [FATAL] %!(EXTRA string=	not a directory or does not exist: /user/home/.gopm/repos/github.com/hoge/test)

> cat /user/home/.gopm/data/localnodes.list
[github.com/hoge/test]
value = fe6ea2c8e398672518ef204bf0fbd9af858d0e15

> rm /user/home/.gopm/data/localnodes.list

> gopm get -g -v -u
・・・
[GOPM] 15-11-12 11:24:44 [ INFO] Command executed successfully!
```